### PR TITLE
tests for src/functions.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,62 +19,62 @@ protparam(rituximab)
 
 ```
 ProtParam
-       	Query protein sequence:
-       		QVQLQQPGAELVKPGASVKMSCKASGYTFTSYNMHWVKQTPGRGLEWIGAYPGNGDTSYN
-       		QKFKGKATLTADKSSSTAYMQLSSLTSEDSAVYYCARSTYYGGDWYFNVWAGTTVTVSA
+	Query protein sequence:
+		QVQLQQPGAELVKPGASVKMSCKASGYTFTSYNMHWVKQTPGRGLEWIGAYPGNGDTSYN
+		QKFKGKATLTADKSSSTAYMQLSSLTSEDSAVYYCARSTYYGGDWYFNVWAGTTVTVSA
 
-       	Theoretical pI:				0
-       	Molecular weight:      			12984.442140000005
-       	Number of amino acids in protein:      	119
-       	Number of atoms in protein:    		1781
+	Theoretical pI:				8.86279296875
+	Molecular weight:			12984.442140000005
+	Number of amino acids in protein:	119
+	Number of atoms in protein:		1781
 
-       	Total number of negatively charged residues (Asp + Glu):       	7
-       	Total number of positively charged residues (Arg + Lys):       	10
+	Total number of negatively charged residues (Asp + Glu):	7
+	Total number of positively charged residues (Arg + Lys):	10
 
-       	Extinction coefficient, assuming all pairs of Cys residues form cystines:
-       		E:     	37025
-       		Abs:   	2.8514894672248112
-       	Extinction coefficient, assuming all Cys residues are reduced:
-       		E:     	36900
-       		Abs:   	2.841862561528576
+	Extinction coefficient, assuming all pairs of Cys residues form cystines:
+		E:	37025
+		Abs:	2.8514894672248112
+	Extinction coefficient, assuming all Cys residues are reduced:
+		E:	36900
+		Abs:	2.841862561528576
 
-       	Half-life:
-       		Estimated half-life in mammalian reticulocytes, in vitro:      	0.8 hour
-       		Estimated half-life in yeast, in vivo: 				10 min
-       		Estimated half-life in Escherichia coli, in vivo:      		>10 hour
+	Half-life:
+		Estimated half-life in mammalian reticulocytes, in vitro:	0.8 hour
+		Estimated half-life in yeast, in vivo:				10 min
+		Estimated half-life in Escherichia coli, in vivo:		>10 hour
 
-       	The instability index (II):    	0
-       	This classifies the protein as stable.
+	The instability index (II):	32.99495798319327
+	This classifies the protein as stable.
 
-       	Aliphatic index of a protein:  		51.68067226890756
-       	Grand Average of Hydropathy (GRAVY):   	-0.4537815126050419
+	Aliphatic index of a protein:		51.68067226890756
+	Grand Average of Hydropathy (GRAVY):	-0.4537815126050419
 
-       	Amino acids composition:
-       		A      	11
-       		C      	2
-       		D      	4
-       		E      	3
-       		F      	3
-       		G      	12
-       		H      	1
-       		I      	1
-       		K      	8
-       		L      	6
-       		M      	3
-       		N      	4
-       		P      	4
-       		Q      	7
-       		R      	2
-       		T      	12
-       		S      	14
-       		V      	8
-       		W      	4
-       		Y      	10
+	Amino acids composition:
+		A	11
+		C	2
+		D	4
+		E	3
+		F	3
+		G	12
+		H	1
+		I	1
+		K	8
+		L	6
+		M	3
+		N	4
+		P	4
+		Q	7
+		R	2
+		T	12
+		S	14
+		V	8
+		W	4
+		Y	10
 
-       	Atoms composition:
-       		S      	5
-       		C      	579
-       		H      	866
-       		N      	150
-       		O      	181
+	Atoms composition:
+		O	181
+		H	866
+		C	579
+		N	150
+		S	5
 ```

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -21,7 +21,7 @@ function half_life(protein::AminoAcidSequence, make_string::Bool=true)
     if !make_string
         result
     else
-        Dict{ASCIIString, Int}(map(x -> names[x[0]] => x[1], result))
+        Dict{ASCIIString, Int}(map(x -> names[x[1]] => x[2], result))
     end
 end
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -21,7 +21,7 @@ function half_life(protein::AminoAcidSequence, make_string::Bool=true)
     if !make_string
         result
     else
-        Dict{ASCIIString, Int}(map(x -> names[x[1]] => x[2], result))
+        Dict{ASCIIString, ASCIIString}(map(x -> names[x[1]] => x[2], result))
     end
 end
 

--- a/test/functions_tests.jl
+++ b/test/functions_tests.jl
@@ -13,7 +13,8 @@ import ProtParam:
     absorbance,
     atom_composition,
     number_of_atoms,
-    aliphatic_index
+    aliphatic_index,
+    ProtParamType
 
 test_data = [
     (
@@ -22,15 +23,25 @@ test_data = [
         Dict(
             "negativecount" => 7,
             "positivecount" => 10,
-            #"half_life" => ,
+            "half_life" => Dict(
+                "Mammalian, in vitro" => "0.8 hour",
+                "Yeast, in vivo" => "10 min",
+                "E.Coli, in vivo" => "10 hour"
+            ), # this dict is used to test half_life function with `make_string` parameter set to true
             "instability_index" => 32.99,
             "stability" => "stable",
             "isoelectric_point" => 8.86,
             "gravy" => -0.454,
-            #"extinction_coeff" => 
+            "extinction_coeff" => (36900,37025), 
             "molecular_weight" => 12984.44,
-            #"absorbance" =>
-            #"atom_composition" =>
+            "absorbance" => (2.842, 2.851),
+            "atom_composition" => Dict(
+                ATOM_S => 5,
+                ATOM_C => 579,
+                ATOM_H => 866,
+                ATOM_N => 150,
+                ATOM_O => 181
+            ),
             "number_of_atoms" => 1781,
             "aliphatic_index" => 51.68
         )
@@ -41,15 +52,25 @@ test_data = [
         Dict(
             "negativecount" => 41,
             "positivecount" => 24,
-            #"half_life" => 
+            "half_life" => Dict(
+                "Mammalian, in vitro" => "30 hour",
+                "Yeast, in vivo" => ">20 hour",
+                "E.Coli, in vivo" => ">10 hour"
+            ), # this dict is used to test half_life function with `make_string` parameter set to true
             "instability_index" => 45.15,
             "stability" => "unstable",
             "isoelectric_point" => 4.57,
             "gravy" => -0.095,
-            #"extinction_coeff" => 
+            "extinction_coeff" => (15930,16305), 
             "molecular_weight" => 28768.78,
-            #"absorbance" =>
-            #"atom_composition" =>
+            "absorbance" => (0.554, 0.567),
+            "atom_composition" => Dict(
+                ATOM_S => 16,
+                ATOM_C => 1257,
+                ATOM_H => 2020,
+                ATOM_N => 328,
+                ATOM_O => 408
+            ),
             "number_of_atoms" => 4029,
             "aliphatic_index" => 94.87
         )
@@ -60,27 +81,44 @@ test_data = [
         Dict(
             "negativecount" => 1,
             "positivecount" => 4,
-            #"half_life" => 
+            "half_life" => Dict(
+                "Mammalian, in vitro" => "1 hour",
+                "Yeast, in vivo" => "2 min",
+                "E.Coli, in vivo" => "2 min"
+            ), # this dict is used to test half_life function with `make_string` parameter set to true
             "instability_index" => 44.64,
             "stability" => "unstable",
             "isoelectric_point" => 10.05,
             "gravy" => -0.090,
-            #"extinction_coeff" => 
+            "extinction_coeff" => (0, 0),
             "molecular_weight" => 2250.72,
-            #"absorbance" =>
-            #"atom_composition" =>
+            "absorbance" => (0, 0),
+            "atom_composition" => Dict(
+                ATOM_S => 3,
+                ATOM_C => 93,
+                ATOM_H => 168,
+                ATOM_N => 30,
+                ATOM_O => 28
+            ),
             "number_of_atoms" => 322,
             "aliphatic_index" => 97.50
         )
     )
 ]
 
+aa1 = test_data[1][2]
+println(atom_composition(aa1))
+#println(show(half_life(aa1)))
 for (name, sequence, data) in test_data
     facts(string("Run tests for ", name)) do
         for (function_name, expected_result) in data
             result = eval(Expr(:call, symbol(function_name), sequence))
             if isa(result, Number)
                 @fact result --> roughly(expected_result, 0.01)
+            elseif isa(result, Tuple)
+                for (u, v) in zip(result, expected_result)
+                    @fact u --> (isa(v, Number) ? roughly(v, 0.01) : v)
+                end
             else
                 @fact result --> expected_result
             end

--- a/test/functions_tests.jl
+++ b/test/functions_tests.jl
@@ -1,137 +1,89 @@
 # This test set ensures that methods from `src/functions.jl` behave the same way as they should
 # This is checked by comparing results of particular methods with corresponding output from ExPASy.
-import ProtParam: *
-rituximab = aa"QVQLQQPGAELVKPGASVKMSCKASGYTFTSYNMHWVKQTPGRGLEWIGAYPGNGDTSYNQKFKGKATLTADKSSSTAYMQLSSLTSEDSAVYYCARSTYYGGDWYFNVWAGTTVTVSA"
-PCNA = aa"MFEARLVQGSILKKVLEALKDLINEACWDISSSGVNLQSMDSSHVSLVQLTLRSEGFDTYRCDRNLAMGVNLTSMSKILKCAGNEDIITLRAEDNADTLALVFEAPNQEKVSDYEMKLMDLDVEQLGIPEQEYSCVVKMPSGEFARICRDLSHIGDAVVISCAKDGVKFSASGELGNGNIKLSQTSNVDKEEEAVTIEMNEPVQLTFALRYLNFFTKATPLSSTVTLSMSADVPLVVEYKIADMGHLKYYLAPKIEDEEGS" 
+import ProtParam: 
+    negativecount,
+    positivecount,
+    half_life,
+    instability_index,
+    stability,
+    isoelectric_point, 
+    gravy,
+    extinction_coeff,
+    molecular_weight,
+    absorbance,
+    atom_composition,
+    number_of_atoms,
+    aliphatic_index
 
-facts("negativecount computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact negativecount(protein) --> roughly(expected_result, 0.01)
-    end
-end
+test_data = [
+    (
+        "rituximab",
+        aa"QVQLQQPGAELVKPGASVKMSCKASGYTFTSYNMHWVKQTPGRGLEWIGAYPGNGDTSYNQKFKGKATLTADKSSSTAYMQLSSLTSEDSAVYYCARSTYYGGDWYFNVWAGTTVTVSA",
+        Dict(
+            "negativecount" => 7,
+            "positivecount" => 10,
+            #"half_life" => ,
+            "instability_index" => 32.99,
+            "stability" => "stable",
+            "isoelectric_point" => 8.86,
+            "gravy" => -0.454,
+            #"extinction_coeff" => 
+            "molecular_weight" => 12984.44,
+            #"absorbance" =>
+            #"atom_composition" =>
+            "number_of_atoms" => 1781,
+            "aliphatic_index" => 51.68
+        )
+    ), 
+    (   
+        "PCNA",
+        aa"MFEARLVQGSILKKVLEALKDLINEACWDISSSGVNLQSMDSSHVSLVQLTLRSEGFDTYRCDRNLAMGVNLTSMSKILKCAGNEDIITLRAEDNADTLALVFEAPNQEKVSDYEMKLMDLDVEQLGIPEQEYSCVVKMPSGEFARICRDLSHIGDAVVISCAKDGVKFSASGELGNGNIKLSQTSNVDKEEEAVTIEMNEPVQLTFALRYLNFFTKATPLSSTVTLSMSADVPLVVEYKIADMGHLKYYLAPKIEDEEGS",
+        Dict(
+            "negativecount" => 41,
+            "positivecount" => 24,
+            #"half_life" => 
+            "instability_index" => 45.15,
+            "stability" => "unstable",
+            "isoelectric_point" => 4.57,
+            "gravy" => -0.095,
+            #"extinction_coeff" => 
+            "molecular_weight" => 28768.78,
+            #"absorbance" =>
+            #"atom_composition" =>
+            "number_of_atoms" => 4029,
+            "aliphatic_index" => 94.87
+        )
+    ),
+    (
+        "PCNA fragment",
+        aa"RCDRNLAMGVNLTSMSKILK",
+        Dict(
+            "negativecount" => 1,
+            "positivecount" => 4,
+            #"half_life" => 
+            "instability_index" => 44.64,
+            "stability" => "unstable",
+            "isoelectric_point" => 10.05,
+            "gravy" => -0.090,
+            #"extinction_coeff" => 
+            "molecular_weight" => 2250.72,
+            #"absorbance" =>
+            #"atom_composition" =>
+            "number_of_atoms" => 322,
+            "aliphatic_index" => 97.50
+        )
+    )
+]
 
-facts("positivecount computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact positivecount(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-facts("half_life computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact half_life(protein) --> roughly(expected_result, 0.01)
-        @pending half_life(protein, false)
-    end
-end
-
-facts("instability_index computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact instability_index(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-facts("stability computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact stability(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-# compute theoretical pI for several sequences and compare with Compute pI/Mw output
-facts("isoelectric_point computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact isoelectric_point(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-facts("gravy computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact gravy(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-facts("extinction_coeff computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact extinction_coeff(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-facts("molecular_weight computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact molecular_weight(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-facts("absorbance computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact absorbance(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-facts("atom_composition computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact atom_composition(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-facts("number_of_atoms computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact number_of_atoms(protein) --> roughly(expected_result, 0.01)
-    end
-end
-
-facts("aliphatic_index computation") do
-    for (protein, expected_result) in [
-        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-        (rituximab, 8.86),
-        (PCNA, 4.57)
-    ]
-        @fact aliphatic_index(protein) --> roughly(expected_result, 0.01)
+for (name, sequence, data) in test_data
+    facts(string("Run tests for ", name)) do
+        for (function_name, expected_result) in data
+            result = eval(Expr(:call, symbol(function_name), sequence))
+            if isa(result, Number)
+                @fact result --> roughly(expected_result, 0.01)
+            else
+                @fact result --> expected_result
+            end
+        end
     end
 end

--- a/test/functions_tests.jl
+++ b/test/functions_tests.jl
@@ -106,13 +106,13 @@ test_data = [
     )
 ]
 
-aa1 = test_data[1][2]
-println(atom_composition(aa1))
-#println(show(half_life(aa1)))
+# Following code cycles through examples given in test_data array, for each of 
+# them compares values of functions (each function given as a key in Dict) with
+# corresponding expected values (which were taken from ExPASy output).
 for (name, sequence, data) in test_data
     facts(string("Run tests for ", name)) do
         for (function_name, expected_result) in data
-            result = eval(Expr(:call, symbol(function_name), sequence))
+            result = eval(Expr(:call, Symbol(function_name), sequence))
             if isa(result, Number)
                 @fact result --> roughly(expected_result, 0.01)
             elseif isa(result, Tuple)

--- a/test/functions_tests.jl
+++ b/test/functions_tests.jl
@@ -1,0 +1,137 @@
+# This test set ensures that methods from `src/functions.jl` behave the same way as they should
+# This is checked by comparing results of particular methods with corresponding output from ExPASy.
+import ProtParam: *
+rituximab = aa"QVQLQQPGAELVKPGASVKMSCKASGYTFTSYNMHWVKQTPGRGLEWIGAYPGNGDTSYNQKFKGKATLTADKSSSTAYMQLSSLTSEDSAVYYCARSTYYGGDWYFNVWAGTTVTVSA"
+PCNA = aa"MFEARLVQGSILKKVLEALKDLINEACWDISSSGVNLQSMDSSHVSLVQLTLRSEGFDTYRCDRNLAMGVNLTSMSKILKCAGNEDIITLRAEDNADTLALVFEAPNQEKVSDYEMKLMDLDVEQLGIPEQEYSCVVKMPSGEFARICRDLSHIGDAVVISCAKDGVKFSASGELGNGNIKLSQTSNVDKEEEAVTIEMNEPVQLTFALRYLNFFTKATPLSSTVTLSMSADVPLVVEYKIADMGHLKYYLAPKIEDEEGS" 
+
+facts("negativecount computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact negativecount(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("positivecount computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact positivecount(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("half_life computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact half_life(protein) --> roughly(expected_result, 0.01)
+        @pending half_life(protein, false)
+    end
+end
+
+facts("instability_index computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact instability_index(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("stability computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact stability(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+# compute theoretical pI for several sequences and compare with Compute pI/Mw output
+facts("isoelectric_point computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact isoelectric_point(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("gravy computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact gravy(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("extinction_coeff computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact extinction_coeff(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("molecular_weight computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact molecular_weight(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("absorbance computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact absorbance(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("atom_composition computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact atom_composition(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("number_of_atoms computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact number_of_atoms(protein) --> roughly(expected_result, 0.01)
+    end
+end
+
+facts("aliphatic_index computation") do
+    for (protein, expected_result) in [
+        (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
+        (rituximab, 8.86),
+        (PCNA, 4.57)
+    ]
+        @fact aliphatic_index(protein) --> roughly(expected_result, 0.01)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,6 @@
 using ProtParam
 using Base.Test, FactCheck
 
-rituximab = aa"QVQLQQPGAELVKPGASVKMSCKASGYTFTSYNMHWVKQTPGRGLEWIGAYPGNGDTSYNQKFKGKATLTADKSSSTAYMQLSSLTSEDSAVYYCARSTYYGGDWYFNVWAGTTVTVSA"
-PCNA = aa"MFEARLVQGSILKKVLEALKDLINEACWDISSSGVNLQSMDSSHVSLVQLTLRSEGFDTYRCDRNLAMGVNLTSMSKILKCAGNEDIITLRAEDNADTLALVFEAPNQEKVSDYEMKLMDLDVEQLGIPEQEYSCVVKMPSGEFARICRDLSHIGDAVVISCAKDGVKFSASGELGNGNIKLSQTSNVDKEEEAVTIEMNEPVQLTFALRYLNFFTKATPLSSTVTLSMSADVPLVVEYKIADMGHLKYYLAPKIEDEEGS" 
-
-import ProtParam: isoelectric_point
-# compute theoretical pI for several sequences and compare with Compute pI/Mw output
-for (protein, expected_result) in [
-    (aa"RCDRNLAMGVNLTSMSKILK", 10.05),
-    (rituximab, 8.86),
-    (PCNA, 4.57)
-]
-    @test_approx_eq_eps expected_result isoelectric_point(protein) 0.01
-end
-
+include("functions_tests.jl")
+#add acidparam_tests.jl - to check if aminoacid params are saved in constructor
 FactCheck.exitstatus()


### PR DESCRIPTION
Hi, 
I've added simple smoke tests for src/functions.jl (and placed them to test/functions_tests.jl).
Notes:
- There is no exact correspondence between isoelectric point computation in this implementation and in ExPASy - for now this implementation doesn't produce erranous pI values (FRAGMENT, UNDEFINED or
  XXX) => behaviour with erranous data in this or other cases is not checked.
- **At this point Travis CI will fail with 1 test**. The reason is that half-life for e.coli differs in tables in reference article and documentation page from  value, produced by ExPASy itself (and it will differ for every amino acid with Q\Gln in N-terminus :) ). I can set table value as an expected one and add a note to `README.md` page. And I could write ExPASy authors (to eliminate this error from there - if this is error in output, not in table data) if you like. @zmactep what do you think about it?
- Is it true that this tool's output should not look exactly the same as ExPASy output? 
- You probably also have "Tabs to spaces" or similar tool installed - and in README.md it converted leading tabs to spaces in sample output (or you made it intentionally?). fixed this to latest output (with pI+II values).
- also fixed 1 typo in `half_life`

This pull request should be merged as 1 commit.
